### PR TITLE
build: sign and notarize the macOS DMG with a Developer ID certificate

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -268,12 +268,29 @@ compose.desktop {
             macOS {
                 iconFile.set(project.file("icon.icns"))
                 bundleID = "de.fampopprol.dhbw"
-                // For Mac App Store, you'll need to configure signing:
-                // signing {
-                //     sign.set(true)
-                //     identity.set("3rd Party Mac Developer Application: Your Name (TEAM_ID)")
-                // }
-                // appStore.set(true)
+
+                // Developer ID signing + notarization for distribution outside the App
+                // Store.  Every value comes from the environment so that neither the
+                // identity nor the app-specific password lands in the repo or shows up in
+                // the process list, as it would with -P properties.  When
+                // APPLE_SIGN_IDENTITY is unset (Linux/Windows runners, ordinary dev
+                // builds) the build stays unsigned and behaves exactly as before.
+                val signIdentity = project.providers.environmentVariable("APPLE_SIGN_IDENTITY")
+                signing {
+                    sign.set(signIdentity.map { it.isNotBlank() }.orElse(false))
+                    identity.set(signIdentity)
+                }
+                notarization {
+                    appleID.set(project.providers.environmentVariable("APPLE_ID"))
+                    password.set(project.providers.environmentVariable("APPLE_APP_PASSWORD"))
+                    teamID.set(project.providers.environmentVariable("APPLE_TEAM_ID"))
+                }
+                // entitlementsFile is deliberately left unset: the Compose plugin defaults
+                // (allow-jit, allow-unsigned-executable-memory, disable-library-validation)
+                // are exactly what the JVM needs under the hardened runtime.
+                // macOS.entitlements is App Store / sandbox specific and would break a
+                // Developer ID build.
+                // appStore.set(true)  // only for the Mac App Store route (PKG instead of DMG)
             }
             linux {
                 iconFile.set(project.file("icon.png"))
@@ -282,6 +299,19 @@ compose.desktop {
     }
 }
 
+
+// The Compose notarization task holds an `ascProvider` property deprecated at
+// DeprecationLevel.ERROR whose provider always throws when read.  The configuration
+// cache serializes the whole settings bean and trips over it, so `notarizeDmg` never
+// starts while the cache is enabled (Compose 1.10.3).  The property cannot be
+// neutralized from the build script because ERROR deprecation blocks any reference to
+// it, so mark the tasks as cache-incompatible instead: Gradle then disables the
+// configuration cache for that single run rather than failing the build.
+tasks.matching { it.name.startsWith("notarize") }.configureEach {
+    notCompatibleWithConfigurationCache(
+        "Compose 1.10.3: MacOSNotarizationSettings.ascProvider is not serializable"
+    )
+}
 
 compose.resources {
     packageOfResClass = "de.fampopprol.dhbwhorb.resources"


### PR DESCRIPTION
## What

Wires up Developer ID signing and Apple notarization for the macOS DMG in `composeApp/build.gradle.kts`.

## Why

The DMG built by the release workflow is unsigned, so macOS shows a Gatekeeper warning the first time a user opens it. Signing the DMG alone would not fix this — Gatekeeper inspects the `.app` *inside* the DMG, and an unnotarized app is rejected even with a valid signature. So the app bundle itself is now signed with a Developer ID Application certificate under the hardened runtime, and the resulting DMG is submitted to Apple's notary service and stapled.

## How to use it

```bash
export APPLE_SIGN_IDENTITY="Developer ID Application: … (TEAMID)" APPLE_ID="…" APPLE_TEAM_ID="…"
read -rs "APPLE_APP_PASSWORD?App-specific password: " && export APPLE_APP_PASSWORD
./gradlew :composeApp:notarizeDmg
```

`notarizeDmg` depends on `packageDmg`, so building, signing, uploading and stapling happen in one run. Verify with:

```bash
spctl -a -t open --context context:primary-signature -vv composeApp/build/compose/binaries/main/dmg/*.dmg
```

## Notes for reviewers

**Credentials come from the environment, not Gradle properties.** The Compose DSL also accepts `-Pcompose.desktop.mac.notarization.password=…`, but that would put the app-specific password in the process list. Environment variables keep it out of both the repo and `ps`.

**Unset variables are a no-op.** If `APPLE_SIGN_IDENTITY` is absent, `sign` resolves to `false` and the build produces an unsigned DMG exactly as before. The Linux and Windows CI jobs are unaffected, and `build-release.yml` is not touched by this PR — signing still happens locally for now.

**`entitlementsFile` is deliberately left unset.** The Compose plugin's defaults (`allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`) are precisely what a JVM app needs under the hardened runtime. The existing `composeApp/macOS.entitlements` is App Store specific — it enables the App Sandbox and contains a `$(AppIdentifierPrefix)` placeholder that only Xcode substitutes, which `codesign` would sign literally — and pointing at it would break a Developer ID build.

**The configuration-cache workaround.** `MacOSNotarizationSettings` holds an `ascProvider` property deprecated at `DeprecationLevel.ERROR` whose provider unconditionally throws when read. Gradle's configuration cache serializes the entire nested settings bean and hits it, failing the build before `notarizeDmg` can start. This affects anyone invoking the task with the cache enabled (it is on in `gradle.properties`), regardless of configuration. The property cannot be referenced from the build script to neutralize it, so the notarize tasks are marked `notCompatibleWithConfigurationCache`, which makes Gradle disable the cache for that single invocation instead of aborting.

## Verification

- `./gradlew :composeApp:notarizeDmg --dry-run` → `BUILD SUCCESSFUL`, task graph resolves as `createDistributable` → `packageDmg` → `notarizeDmg`
- `./gradlew :composeApp:packageDmg --dry-run` → `Configuration cache entry stored`, so the cache still works normally for the unsigned path
- Developer ID identity test-signed a throwaway binary: full chain to Apple Root CA, timestamp server reachable, `flags=0x10000(runtime)` applied

An end-to-end notarization run against Apple's service has not been done yet — that requires the app-specific password and is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)