### PR TITLE
Clear all local data on logout, and give the demo account grades and real documents

### DIFF
--- a/core/testing/src/commonMain/kotlin/de/fampopprol/dhbwhorb/testutil/MockAuthenticationService.kt
+++ b/core/testing/src/commonMain/kotlin/de/fampopprol/dhbwhorb/testutil/MockAuthenticationService.kt
@@ -50,7 +50,7 @@ class MockAuthenticationService(
         return Outcome.Ok(Session(userFullName = null, isDemo = false))
     }
 
-    override fun logout() {
+    override suspend fun logout() {
         sessionManager.logout()
     }
 

--- a/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/di/DataModule.kt
+++ b/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/di/DataModule.kt
@@ -46,6 +46,7 @@ import de.fampopprol.dhbwhorb.domain.usecase.LoginWithCredentials
 import de.fampopprol.dhbwhorb.domain.usecase.Logout
 import de.fampopprol.dhbwhorb.domain.usecase.RefreshTimetable
 import de.fampopprol.dhbwhorb.domain.usecase.RestoreSession
+import de.fampopprol.dhbwhorb.net.ClearableCookiesStorage
 import de.fampopprol.dhbwhorb.net.HttpClientFactory
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
@@ -70,12 +71,17 @@ private const val NETWORK_TIMEOUT_MILLIS = 30_000L
  */
 val dataModule = module {
 
+    // Ours rather than the plugin's default, because logout has to be able to empty it — see
+    // ClearableCookiesStorage.
+    single { ClearableCookiesStorage() }
+
     // Cookie storage lives in the client, so authentication and every subsequent request must
     // share this instance — otherwise the session cookie is lost after login.
     single {
+        val cookies: ClearableCookiesStorage = get()
         HttpClientFactory.create {
             expectSuccess = false
-            install(HttpCookies)
+            install(HttpCookies) { storage = cookies }
             install(HttpTimeout) {
                 socketTimeoutMillis = NETWORK_TIMEOUT_MILLIS
                 connectTimeoutMillis = NETWORK_TIMEOUT_MILLIS
@@ -86,7 +92,9 @@ val dataModule = module {
 
     single { DualisApiClient(client = get()) }
     single { SessionManager(secureStorage = get()) }
-    single { AuthenticationService(sessionManager = get(), client = get()) }
+    single {
+        AuthenticationService(sessionManager = get(), client = get(), cookiesStorage = get())
+    }
     single { CredentialsStorageProvider(secureStorage = get()) }
 
     // One re-authenticator for the whole app: it is what makes concurrent 401s share a single
@@ -171,7 +179,9 @@ val dataModule = module {
     // Use cases are factories: they hold no state, so there is nothing to share between callers.
     factory { LoginWithCredentials(authRepository = get()) }
     factory { RestoreSession(sessionRepository = get(), authRepository = get()) }
-    factory { Logout(authRepository = get()) }
+    // The cleaner comes from :services, which this module cannot see and which is loaded next to
+    // it — getOrNull, so a graph without it (the tests, the widget extension) still logs out.
+    factory { Logout(authRepository = get(), cleaner = getOrNull()) }
 
     factory { GetWeekTimetable(repository = get()) }
     factory { AwaitFullWeekTimetable(repository = get()) }

--- a/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/dualis/demo/DemoDataProvider.kt
+++ b/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/dualis/demo/DemoDataProvider.kt
@@ -1,12 +1,17 @@
 package de.fampopprol.dhbwhorb.data.dualis.demo
 
 import de.fampopprol.dhbwhorb.data.dualis.models.DualisDocument
+import de.fampopprol.dhbwhorb.data.helpers.TimeHelper
+import de.fampopprol.dhbwhorb.data.storage.database.entities.grades.GradeEntity
 import de.fampopprol.dhbwhorb.data.storage.database.entities.timetable.LectureEventEntity
 import de.fampopprol.dhbwhorb.data.storage.database.entities.timetable.LecturerEntity
+import de.fampopprol.dhbwhorb.domain.model.Semester
 import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.isoDayNumber
+import kotlinx.datetime.number
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.ExperimentalTime
@@ -259,32 +264,249 @@ object DemoDataProvider {
      * Generate demo lecturers.
      */
     /**
+     * The semesters the demo account has studied, newest first — the order Dualis fills its
+     * dropdown in.
+     *
+     * Derived from the current date rather than written down, for the same reason the demo
+     * timetable is generated around the current week: a fixture with "WiSe 2024/25" in it looks
+     * abandoned two years later, and the demo account is the first thing a new user sees.
+     *
+     * @param today the date the demo is being looked at, injectable for the tests
+     */
+    fun demoSemesters(today: LocalDate = TimeHelper.now().date): List<Semester> {
+        val current = semesterOf(today)
+        return listOf(current, current.previous(), current.previous().previous())
+            .mapIndexed { index, term ->
+                // Index 0 is the current semester, so the id counts backwards: the oldest of the
+                // three is the student's first.
+                Semester(id = "$DEMO_SEMESTER_ID_PREFIX${DEMO_SEMESTER_COUNT - index}", name = term.displayName)
+            }
+    }
+
+    /**
+     * The grades of one demo semester, or an empty list for a semester the demo does not have.
+     *
+     * Three semesters of a dual computer science course: two finished, the current one still
+     * running. The mix is deliberate — numeric grades, a "b" for a module that is only ever
+     * passed or failed, and modules with no grade yet — because those are the three cases the
+     * grades screen and the average have to survive, and a fixture where every module has a
+     * number tests none of them.
+     *
+     * The current semester holds the modules the demo timetable teaches, so the two screens
+     * describe the same student.
+     */
+    fun demoGrades(semester: Semester, studentId: String): List<GradeEntity> {
+        val modules = when (semester.id) {
+            "${DEMO_SEMESTER_ID_PREFIX}1" -> firstSemesterModules
+            "${DEMO_SEMESTER_ID_PREFIX}2" -> secondSemesterModules
+            "${DEMO_SEMESTER_ID_PREFIX}3" -> currentSemesterModules
+            else -> return emptyList()
+        }
+
+        return modules.map { module ->
+            GradeEntity(
+                studentId = studentId,
+                semesterId = semester.id,
+                semesterName = semester.name,
+                moduleNumber = module.number,
+                moduleName = module.name,
+                grade = module.grade,
+                credits = module.credits,
+                // Dualis writes the German words, and the app shows the column as it comes.
+                status = if (module.grade == null) "offen" else "bestanden"
+            )
+        }
+    }
+
+    /** One row of the grade table, before it knows which semester or student it belongs to. */
+    private data class DemoModule(
+        val number: String,
+        val name: String,
+        val grade: String?,
+        val credits: Double
+    )
+
+    private val firstSemesterModules = listOf(
+        DemoModule("T3INF1001", "Mathematik I", "1,7", 6.0),
+        DemoModule("T3INF1002", "Programmierung 1", "1,3", 8.0),
+        DemoModule("T3INF1003", "Theoretische Informatik I", "2,3", 5.0),
+        DemoModule("T3INF1004", "Grundlagen der Informatik", "2,0", 5.0),
+        // Passed or not passed, never a number — the case that makes numericGrade null on a
+        // module that is nonetheless finished and whose credits count.
+        DemoModule("T3INF1900", "Praxisprojekt I", "b", 6.0)
+    )
+
+    private val secondSemesterModules = listOf(
+        DemoModule("T3INF2001", "Mathematik II", "2,0", 6.0),
+        DemoModule("T3INF2002", "Algorithmen und Datenstrukturen", "1,7", 6.0),
+        DemoModule("T3INF2003", "Programmierung 2", "1,3", 6.0),
+        DemoModule("T3INF2004", "Technische Informatik", "2,7", 5.0),
+        DemoModule("T3INF2005", "Betriebswirtschaftslehre", "2,3", 4.0),
+        DemoModule("T3INF2900", "Praxisprojekt II", "b", 8.0)
+    )
+
+    private val currentSemesterModules = listOf(
+        DemoModule("T3INF3001", "Software Engineering", "1,7", 5.0),
+        DemoModule("T3INF3002", "Projektmanagement", "2,0", 4.0),
+        DemoModule("T3INF3003", "Web Engineering", null, 5.0),
+        DemoModule("T3INF3004", "Datenbanken und Informationssysteme", null, 6.0),
+        DemoModule("T3INF3005", "Theoretische Informatik II", null, 5.0),
+        DemoModule("T3INF3006", "Netzwerktechnik", null, 5.0)
+    )
+
+    private const val DEMO_SEMESTER_ID_PREFIX = "demo-semester-"
+    private const val DEMO_SEMESTER_COUNT = 3
+
+    /** A term as Dualis names it: "WiSe 2025/26" or "SoSe 2026". */
+    private data class Term(val startYear: Int, val isWinter: Boolean) {
+        val displayName: String
+            get() = if (isWinter) {
+                // Two digits, so 2099/2100 reads "2099/00" the way Dualis writes it.
+                val endYear = ((startYear + 1) % 100).toString().padStart(2, '0')
+                "WiSe $startYear/$endYear"
+            } else {
+                "SoSe $startYear"
+            }
+
+        /** The term before this one. Winter starts the academic year, so it follows that summer. */
+        fun previous(): Term =
+            if (isWinter) Term(startYear, isWinter = false) else Term(startYear - 1, isWinter = true)
+    }
+
+    /**
+     * The term [date] falls into: the summer one from March to August, the winter one otherwise —
+     * and a winter term is named after the year it *starts* in, so January belongs to the term
+     * that began the previous autumn.
+     */
+    private fun semesterOf(date: LocalDate): Term {
+        val month = date.month.number
+        return when {
+            month in 3..8 -> Term(date.year, isWinter = false)
+            month >= 9 -> Term(date.year, isWinter = true)
+            else -> Term(date.year - 1, isWinter = true)
+        }
+    }
+
+    /**
      * The documents the demo account shows.
      *
-     * They are listed but cannot be downloaded — there is no file behind the URLs, which is why
-     * [de.fampopprol.dhbwhorb.data.dualis.remote.services.DualisDocumentService.downloadDocument]
-     * reports them as unsupported rather than letting the request fail.
+     * Each of them downloads: [demoDocumentContent] renders the PDF the viewer opens, so the
+     * demo goes all the way through the list-open-save flow rather than stopping at a message.
      */
-    fun demoDocuments(): List<DualisDocument> = listOf(
+    fun demoDocuments(today: LocalDate = TimeHelper.now().date): List<DualisDocument> = listOf(
         DualisDocument(
             title = "Studienbescheinigung",
-            date = "25.03.26",
+            // Dated relative to today for the same reason the timetable is: a demo whose newest
+            // document is from two years ago looks like a broken account, not like a preview.
+            date = today.minusDays(12).asDualisDate(),
             time = "09:40",
-            downloadUrl = "/scripts/filetransfer.exe?demo_cert"
+            downloadUrl = DEMO_DOCUMENT_CERTIFICATE
         ),
         DualisDocument(
             title = "Zahlungsinformation Semesterbeiträge",
-            date = "19.02.26",
+            date = today.minusDays(34).asDualisDate(),
             time = "14:47",
-            downloadUrl = "/scripts/filetransfer.exe?demo_payment"
+            downloadUrl = DEMO_DOCUMENT_PAYMENT
         ),
         DualisDocument(
             title = "Semesternotenbescheid - Download",
-            date = "11.02.26",
+            date = today.minusDays(61).asDualisDate(),
             time = "15:52",
-            downloadUrl = "/scripts/filetransfer.exe?demo_grades"
+            downloadUrl = DEMO_DOCUMENT_GRADES
         )
     )
+
+    /**
+     * The file behind a demo document, or null for a URL that is not one of them.
+     *
+     * A real PDF rather than a placeholder: the download path ends in the platform's own viewer
+     * and save dialog, and handing those an empty array or a text file is how the demo would
+     * "work" everywhere except on a device.
+     *
+     * Keyed by [downloadUrl] because that is all Dualis gives a caller to ask for a file with,
+     * and the demo behaves the same way.
+     */
+    fun demoDocumentContent(
+        downloadUrl: String,
+        today: LocalDate = TimeHelper.now().date
+    ): ByteArray? {
+        val document = demoDocuments(today).find { it.downloadUrl == downloadUrl } ?: return null
+        val issued = "${document.date}, ${document.time} Uhr"
+        val student = "Max Mustermann, Matrikelnummer 1234567"
+
+        return when (document.downloadUrl) {
+            DEMO_DOCUMENT_CERTIFICATE -> DemoPdf.render(
+                title = "Studienbescheinigung",
+                lines = listOf(
+                    "Duale Hochschule Baden-Württemberg",
+                    "Studiengang Informatik (T3INF)",
+                    "",
+                    student,
+                    "Semester: ${demoSemesters(today).first().name}",
+                    "Ausgestellt am $issued",
+                    "",
+                    "Hiermit wird bescheinigt, dass die oben genannte Person im",
+                    "laufenden Semester ordentlich immatrikuliert ist.",
+                    "",
+                    DEMO_FOOTER
+                )
+            )
+
+            DEMO_DOCUMENT_PAYMENT -> DemoPdf.render(
+                title = "Zahlungsinformation Semesterbeiträge",
+                lines = listOf(
+                    student,
+                    "Semester: ${demoSemesters(today).first().name}",
+                    "Ausgestellt am $issued",
+                    "",
+                    "Verwaltungskostenbeitrag         70,00 EUR",
+                    "Studierendenwerksbeitrag         89,00 EUR",
+                    "Studierendenschaftsbeitrag        9,00 EUR",
+                    "-----------------------------------------",
+                    "Gesamtbetrag                    168,00 EUR",
+                    "",
+                    "Der Betrag wurde vollständig verbucht.",
+                    "",
+                    DEMO_FOOTER
+                )
+            )
+
+            DEMO_DOCUMENT_GRADES -> {
+                val semester = demoSemesters(today)[1]
+                DemoPdf.render(
+                    title = "Semesternotenbescheid",
+                    lines = listOf(
+                        student,
+                        "Semester: ${semester.name}",
+                        "Ausgestellt am $issued",
+                        ""
+                    ) + demoGrades(semester, studentId = student).map { grade ->
+                        // Padded into columns; the page is set in Courier so they line up.
+                        "${grade.moduleNumber}  ${grade.moduleName.padEnd(36).take(36)}" +
+                            "${(grade.grade ?: "-").padStart(4)}   " +
+                            "${grade.credits.toString().replace('.', ',')} ECTS"
+                    } + listOf("", DEMO_FOOTER),
+                    monospacedBody = true
+                )
+            }
+
+            else -> null
+        }
+    }
+
+    private const val DEMO_DOCUMENT_CERTIFICATE = "/scripts/filetransfer.exe?demo_cert"
+    private const val DEMO_DOCUMENT_PAYMENT = "/scripts/filetransfer.exe?demo_payment"
+    private const val DEMO_DOCUMENT_GRADES = "/scripts/filetransfer.exe?demo_grades"
+
+    private const val DEMO_FOOTER =
+        "Beispieldokument des Demo-Kontos - keine gültige Bescheinigung."
+
+    /** Dualis writes dates as `dd.MM.yy`. */
+    private fun LocalDate.asDualisDate(): String =
+        "${day.toString().padStart(2, '0')}.${month.number.toString().padStart(2, '0')}." +
+            "${(year % 100).toString().padStart(2, '0')}"
+
+    private fun LocalDate.minusDays(days: Int): LocalDate = plus(-days, DateTimeUnit.DAY)
 
     fun generateDemoLecturers(): List<LecturerEntity> {
         return listOf(

--- a/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/dualis/demo/DemoPdf.kt
+++ b/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/dualis/demo/DemoPdf.kt
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.data.dualis.demo
+
+/**
+ * A one-page PDF, written by hand.
+ *
+ * The demo account has to hand the viewer real bytes: a document that is listed but answers a tap
+ * with "not available" is a dead end, and it leaves the open-and-save path — the part with the
+ * platform file dialogs in it — untried until somebody logs into the real Dualis.
+ *
+ * By hand because the alternative is a PDF library on four platforms for one page of text. The
+ * format allows it: a PDF is a handful of numbered objects, a cross-reference table of their byte
+ * offsets, and a trailer pointing at the catalogue. Only the offsets need care, and they are
+ * counted as the objects are written rather than guessed afterwards.
+ *
+ * Helvetica, because it is one of the fourteen faces every reader has to provide itself — nothing
+ * is embedded, and the file stays under two kilobytes.
+ */
+internal object DemoPdf {
+
+    private const val PAGE_WIDTH = 595
+    private const val PAGE_HEIGHT = 842
+    private const val MARGIN = 64
+    private const val TITLE_SIZE = 18
+    private const val BODY_SIZE = 11
+    private const val LINE_HEIGHT = 18
+
+    /**
+     * @param title the heading, also the first line of the page
+     * @param lines the body, one entry per line; an empty entry is a blank line
+     * @param monospacedBody sets the body in Courier, for a page whose lines are columns — a
+     *   proportional font turns a padded table into a ragged one
+     */
+    fun render(title: String, lines: List<String>, monospacedBody: Boolean = false): ByteArray {
+        val content = contentStream(title, lines, monospacedBody)
+
+        val objects = listOf(
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 $PAGE_WIDTH $PAGE_HEIGHT] " +
+                "/Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Courier /Encoding /WinAnsiEncoding >>",
+            "<< /Length ${content.length} >>\nstream\n$content\nendstream",
+        )
+
+        val out = PdfWriter()
+        out.append("%PDF-1.4\n")
+        // A comment of high bytes, which is how a file says "treat me as binary" to anything that
+        // might otherwise helpfully convert line endings.
+        out.appendBytes(byteArrayOf(0x25, 0xE2.toByte(), 0xE3.toByte(), 0xCF.toByte(), 0xD3.toByte(), 0x0A))
+
+        val offsets = objects.mapIndexed { index, body ->
+            val offset = out.size
+            out.append("${index + 1} 0 obj\n$body\nendobj\n")
+            offset
+        }
+
+        val xrefOffset = out.size
+        out.append("xref\n0 ${objects.size + 1}\n")
+        // Object 0 is always the head of the free list, and every entry is exactly 20 bytes.
+        out.append("0000000000 65535 f \n")
+        offsets.forEach { out.append("${it.toString().padStart(10, '0')} 00000 n \n") }
+
+        out.append("trailer\n<< /Size ${objects.size + 1} /Root 1 0 R >>\nstartxref\n$xrefOffset\n%%EOF\n")
+        return out.toByteArray()
+    }
+
+    private fun contentStream(title: String, lines: List<String>, monospacedBody: Boolean): String {
+        val top = PAGE_HEIGHT - MARGIN
+        val bodyFont = if (monospacedBody) "F2" else "F1"
+        return buildString {
+            append("BT\n/F1 $TITLE_SIZE Tf\n$MARGIN $top Td\n(${escape(title)}) Tj\nET\n")
+            append("BT\n/$bodyFont $BODY_SIZE Tf\n$MARGIN ${top - 2 * LINE_HEIGHT} Td\n$LINE_HEIGHT TL\n")
+            lines.forEach { append("(${escape(it)}) Tj T*\n") }
+            append("ET\n")
+        }
+    }
+
+    /** `(`, `)` and `\` end or escape a string literal, so they have to be escaped themselves. */
+    private fun escape(text: String): String = buildString {
+        text.forEach { char ->
+            when (char) {
+                '(', ')', '\\' -> append('\\').append(char)
+                else -> append(char)
+            }
+        }
+    }
+}
+
+/**
+ * A growing byte buffer that knows how many bytes it holds — which is the whole reason it exists,
+ * because the cross-reference table is a list of byte offsets into the file.
+ *
+ * Text goes in as WinAnsi, the encoding the font declares: for German that is Latin-1, one byte
+ * per character. `encodeToByteArray` would write UTF-8, and "Studienbescheinigung für" would
+ * arrive in the viewer as "fÃ¼r".
+ */
+private class PdfWriter {
+
+    private val bytes = mutableListOf<Byte>()
+
+    val size: Int get() = bytes.size
+
+    fun append(text: String) {
+        text.forEach { char ->
+            val code = char.code
+            // Anything outside Latin-1 has no WinAnsi byte; a question mark is a visible loss
+            // rather than a corrupt file.
+            bytes += if (code <= 0xFF) code.toByte() else '?'.code.toByte()
+        }
+    }
+
+    fun appendBytes(raw: ByteArray) {
+        raw.forEach { bytes += it }
+    }
+
+    fun toByteArray(): ByteArray = bytes.toByteArray()
+}

--- a/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/dualis/remote/services/AuthenticationService.kt
+++ b/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/dualis/remote/services/AuthenticationService.kt
@@ -15,6 +15,7 @@ import de.fampopprol.dhbwhorb.data.dualis.remote.session.SessionManager
 import de.fampopprol.dhbwhorb.data.error.httpStatusToAppError
 import de.fampopprol.dhbwhorb.data.error.toAppError
 import de.fampopprol.dhbwhorb.domain.model.Session
+import de.fampopprol.dhbwhorb.net.ClearableCookiesStorage
 import io.github.aakira.napier.Napier
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.cookies.cookies
@@ -39,6 +40,7 @@ import io.ktor.http.isSuccess
 open class AuthenticationService(
     val sessionManager: SessionManager,
     private val client: HttpClient,
+    private val cookiesStorage: ClearableCookiesStorage? = null,
     private val authParser: AuthParser = AuthParser(),
     private val htmlParser: HtmlParser = HtmlParser()
 ) {
@@ -192,9 +194,13 @@ open class AuthenticationService(
 
     open fun isAuthenticated(): Boolean = sessionManager.isAuthenticated()
 
-    open fun logout() {
+    open suspend fun logout() {
         Napier.d("Logging out", tag = TAG)
         sessionManager.logout()
+
+        // The session cookie is held by the client, not by the session manager. Leaving it there
+        // meant the next login started by presenting the previous account's cookie.
+        cookiesStorage?.clear()
     }
 
     fun close() {

--- a/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/dualis/remote/services/DualisDocumentService.kt
+++ b/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/dualis/remote/services/DualisDocumentService.kt
@@ -58,9 +58,12 @@ class DualisDocumentService(
      */
     suspend fun downloadDocument(url: String): Outcome<ByteArray> {
         if (sessionManager.isDemoMode()) {
-            // Demo documents are fixtures with no file behind them; saying so is more useful than
-            // a download that fails with a network error.
-            return Outcome.Err(AppError.Unsupported("Documents cannot be downloaded in demo mode"))
+            // The demo documents carry their own generated PDF, so the whole download path —
+            // including the platform's viewer and save dialog — works without a Dualis account.
+            val content = DemoDataProvider.demoDocumentContent(url)
+                ?: return Outcome.Err(AppError.Unsupported("Unknown demo document: $url"))
+            Napier.d("Serving demo document (${content.size} bytes)", tag = TAG)
+            return Outcome.Ok(content)
         }
 
         // Dualis hands out relative paths like /scripts/filetransfer.exe?…

--- a/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/dualis/remote/services/DualisGradeService.kt
+++ b/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/data/dualis/remote/services/DualisGradeService.kt
@@ -9,6 +9,7 @@ package de.fampopprol.dhbwhorb.data.dualis.remote.services
 import de.fampopprol.dhbwhorb.core.error.AppError
 import de.fampopprol.dhbwhorb.core.error.Outcome
 import de.fampopprol.dhbwhorb.core.error.map
+import de.fampopprol.dhbwhorb.data.dualis.demo.DemoDataProvider
 import de.fampopprol.dhbwhorb.data.dualis.remote.parser.GradeParser
 import de.fampopprol.dhbwhorb.data.dualis.remote.parser.HtmlParser
 import de.fampopprol.dhbwhorb.data.dualis.remote.session.SessionManager
@@ -45,6 +46,11 @@ class DualisGradeService(
 
     /** The semesters Dualis lists in its dropdown. */
     suspend fun getSemesters(): Outcome<List<Semester>> {
+        if (sessionManager.isDemoMode()) {
+            Napier.d("Returning demo semesters", tag = TAG)
+            return Outcome.Ok(DemoDataProvider.demoSemesters())
+        }
+
         val html = gateway.fetchPage(
             source = "semesters",
             isValid = { htmlParser.isValidGradePage(it) },
@@ -64,6 +70,11 @@ class DualisGradeService(
         forceRefresh: Boolean = false
     ): Outcome<List<GradeEntity>> {
         val studentId = currentStudentId()
+
+        if (sessionManager.isDemoMode()) {
+            Napier.d("Returning demo grades for semester ${semester.id}", tag = TAG)
+            return Outcome.Ok(DemoDataProvider.demoGrades(semester, studentId))
+        }
 
         if (!forceRefresh) {
             when (val cached = readValidCache(studentId, semester.id)) {

--- a/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/net/ClearableCookiesStorage.kt
+++ b/data/src/commonMain/kotlin/de/fampopprol/dhbwhorb/net/ClearableCookiesStorage.kt
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.net
+
+import io.ktor.client.plugins.cookies.AcceptAllCookiesStorage
+import io.ktor.client.plugins.cookies.CookiesStorage
+import io.ktor.http.Cookie
+import io.ktor.http.Url
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Ktor's in-memory cookie storage, with a way to empty it.
+ *
+ * The session cookie Dualis sets lives in the shared [io.ktor.client.HttpClient], not in secure
+ * storage — which is why logging out and logging in as somebody else used to keep sending the
+ * first account's `JSESSIONID`. [AcceptAllCookiesStorage] has no `clear`, and the plugin does not
+ * expose the storage it was built with, so the storage is ours and the delegate is replaced.
+ */
+class ClearableCookiesStorage : CookiesStorage {
+
+    private val mutex = Mutex()
+    private var delegate = AcceptAllCookiesStorage()
+
+    override suspend fun addCookie(requestUrl: Url, cookie: Cookie) {
+        current().addCookie(requestUrl, cookie)
+    }
+
+    override suspend fun get(requestUrl: Url): List<Cookie> = current().get(requestUrl)
+
+    override fun close() {
+        delegate.close()
+    }
+
+    /** Forget every cookie. The storage stays usable — the next login fills it again. */
+    suspend fun clear() {
+        val previous = mutex.withLock {
+            delegate.also { delegate = AcceptAllCookiesStorage() }
+        }
+        previous.close()
+    }
+
+    // Under the lock, so a request in flight during clear() reads one delegate or the other and
+    // never the half-swapped field.
+    private suspend fun current(): AcceptAllCookiesStorage = mutex.withLock { delegate }
+}

--- a/data/src/commonTest/kotlin/de/fampopprol/dhbwhorb/data/dualis/demo/DemoDataProviderTest.kt
+++ b/data/src/commonTest/kotlin/de/fampopprol/dhbwhorb/data/dualis/demo/DemoDataProviderTest.kt
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.data.dualis.demo
+
+import de.fampopprol.dhbwhorb.domain.model.SemesterOrder
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DemoDataProviderTest {
+
+    private val inWinterTerm = LocalDate(2026, 1, 15)
+    private val inSummerTerm = LocalDate(2026, 5, 4)
+
+    @Test
+    fun semestersAreNamedAfterTheTermTheyBelongTo() {
+        // January belongs to the winter term that started the previous autumn.
+        assertEquals("WiSe 2025/26", DemoDataProvider.demoSemesters(inWinterTerm).first().name)
+        assertEquals("SoSe 2026", DemoDataProvider.demoSemesters(inSummerTerm).first().name)
+    }
+
+    @Test
+    fun semestersAreThreeAndInStudiedOrder() {
+        val semesters = DemoDataProvider.demoSemesters(inSummerTerm)
+
+        assertEquals(listOf("SoSe 2026", "WiSe 2025/26", "SoSe 2025"), semesters.map { it.name })
+        // Newest first, so sorting them oldest-first has to reverse them exactly.
+        assertEquals(
+            semesters.map { it.name }.reversed(),
+            semesters.map { it.name }.sortedWith(SemesterOrder.oldestFirst)
+        )
+    }
+
+    @Test
+    fun everyListedSemesterHasGrades_andTheCurrentOneIsStillRunning() {
+        val semesters = DemoDataProvider.demoSemesters(inSummerTerm)
+        val current = semesters.first()
+        val finished = semesters.last()
+
+        val currentGrades = DemoDataProvider.demoGrades(current, studentId = "demo")
+        val finishedGrades = DemoDataProvider.demoGrades(finished, studentId = "demo")
+
+        assertTrue(currentGrades.any { it.grade == null }, "the current semester is not over")
+        assertTrue(currentGrades.all { it.semesterName == current.name })
+        assertTrue(finishedGrades.isNotEmpty() && finishedGrades.all { it.grade != null })
+        assertTrue(finishedGrades.all { it.status == "bestanden" })
+    }
+
+    @Test
+    fun aSemesterTheDemoDoesNotHave_hasNoGrades() {
+        val other = DemoDataProvider.demoSemesters(inSummerTerm).first().copy(id = "42")
+
+        assertEquals(emptyList(), DemoDataProvider.demoGrades(other, studentId = "demo"))
+    }
+
+    @Test
+    fun everyListedDocumentCanBeDownloaded() {
+        for (document in DemoDataProvider.demoDocuments(inSummerTerm)) {
+            val content = DemoDataProvider.demoDocumentContent(document.downloadUrl, inSummerTerm)
+
+            assertNotNull(content, "${document.title} has no file behind it")
+            assertTrue(content.size > 400, "${document.title} is suspiciously small")
+            assertTrue(content.decodeToString().startsWith("%PDF-1.4"), "not a PDF")
+        }
+    }
+
+    @Test
+    fun anUnknownDocumentUrl_hasNoContent() {
+        assertNull(DemoDataProvider.demoDocumentContent("/scripts/filetransfer.exe?nope"))
+    }
+
+    @Test
+    fun documentDatesFollowTheDayTheyAreLookedAt() {
+        val documents = DemoDataProvider.demoDocuments(LocalDate(2026, 5, 4))
+
+        // dd.MM.yy, twelve days before the given date.
+        assertEquals("22.04.26", documents.first().date)
+    }
+}

--- a/data/src/commonTest/kotlin/de/fampopprol/dhbwhorb/data/dualis/demo/DemoPdfTest.kt
+++ b/data/src/commonTest/kotlin/de/fampopprol/dhbwhorb/data/dualis/demo/DemoPdfTest.kt
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.data.dualis.demo
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The parts of a PDF a reader actually refuses to open a file over: the header, the trailer, and
+ * the cross-reference table whose numbers have to be the true byte offsets of the objects.
+ */
+class DemoPdfTest {
+
+    private val pdf = DemoPdf.render(
+        title = "Studienbescheinigung",
+        lines = listOf("Max Mustermann", "", "Semesterbeitrag (bezahlt)", "Grüße aus Horb")
+    )
+
+    private val text = pdf.decodeToString()
+
+    @Test
+    fun itIsAPdfFromStartToEnd() {
+        assertTrue(text.startsWith("%PDF-1.4"))
+        assertTrue(text.trimEnd().endsWith("%%EOF"))
+        assertTrue(text.contains("/Type /Catalog"))
+        assertTrue(text.contains("/BaseFont /Helvetica"))
+        assertTrue(text.contains("/BaseFont /Courier"))
+    }
+
+    @Test
+    fun everyCrossReferenceEntryPointsAtItsObject() {
+        val offsets = Regex("""^(\d{10}) 00000 n $""", RegexOption.MULTILINE)
+            .findAll(text)
+            .map { it.groupValues[1].toInt() }
+            .toList()
+
+        val objects = Regex("""^(\d+) 0 obj$""", RegexOption.MULTILINE).findAll(text).count()
+        assertEquals(objects, offsets.size, "one entry per object, and object 0 is the free one")
+        assertEquals("0 ${objects + 1}", text.substringAfter("xref\n").substringBefore("\n"))
+        offsets.forEachIndexed { index, offset ->
+            val declaration = "${index + 1} 0 obj"
+            assertEquals(
+                declaration,
+                text.substring(offset, offset + declaration.length),
+                "the xref entry for object ${index + 1} points somewhere else"
+            )
+        }
+    }
+
+    @Test
+    fun startxrefPointsAtTheCrossReferenceTable() {
+        val startxref = text.substringAfterLast("startxref").trim().substringBefore("\n").toInt()
+
+        assertEquals("xref", text.substring(startxref, startxref + 4))
+    }
+
+    @Test
+    fun theStreamLengthIsTheNumberOfBytesInIt() {
+        val declared = Regex("""/Length (\d+)""").find(text)!!.groupValues[1].toInt()
+        val stream = text.substringAfter("stream\n").substringBefore("\nendstream")
+
+        assertEquals(declared, stream.length)
+    }
+
+    @Test
+    fun textIsWrittenInTheEncodingTheFontDeclares() {
+        // WinAnsi, so an umlaut is one byte — as UTF-8 it would be two, and readers would show
+        // "GrÃ¼ÃŸe". The bytes are checked rather than the string, because decodeToString()
+        // reads them back as UTF-8 and would hide exactly this.
+        assertTrue(text.contains("/Encoding /WinAnsiEncoding"))
+        assertTrue(pdf.contains(0xFC.toByte()), "ü must be a single WinAnsi byte")
+    }
+
+    @Test
+    fun bracketsInTheTextAreEscaped() {
+        // An unescaped ( ends the string literal early and corrupts the page.
+        assertTrue(text.contains("Semesterbeitrag \\(bezahlt\\)"))
+    }
+}

--- a/data/src/commonTest/kotlin/de/fampopprol/dhbwhorb/data/dualis/remote/services/DualisGradeServiceDemoTest.kt
+++ b/data/src/commonTest/kotlin/de/fampopprol/dhbwhorb/data/dualis/remote/services/DualisGradeServiceDemoTest.kt
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.data.dualis.remote.services
+
+import de.fampopprol.dhbwhorb.core.error.Outcome
+import de.fampopprol.dhbwhorb.data.dualis.remote.DualisApiClient
+import de.fampopprol.dhbwhorb.data.dualis.remote.session.ReAuthenticator
+import de.fampopprol.dhbwhorb.data.dualis.remote.session.SessionManager
+import de.fampopprol.dhbwhorb.data.storage.credentials.FakeSecureStorage
+import de.fampopprol.dhbwhorb.data.storage.database.entities.grades.GradeEntity
+import de.fampopprol.dhbwhorb.domain.model.Semester
+import de.fampopprol.dhbwhorb.testutil.MockGradeCacheMetadataDao
+import de.fampopprol.dhbwhorb.testutil.MockGradeDao
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The demo account has its own grades.
+ *
+ * Before they existed the request walked into the page gateway, found no session id, could not
+ * re-authenticate an account that never logs in, and ended as "your session has expired" — advice
+ * that leads nowhere for a user who has no session to expire.
+ */
+class DualisGradeServiceDemoTest {
+
+    private var requests = 0
+
+    private fun Outcome<List<GradeEntity>>.gradesOrFail(): List<GradeEntity> =
+        assertIs<Outcome.Ok<List<GradeEntity>>>(this).value
+
+    private fun createService(demo: Boolean): DualisGradeService {
+        val sessionManager = SessionManager(FakeSecureStorage())
+        sessionManager.setDemoMode(demo)
+        sessionManager.storeCredentials(SessionManager.DEMO_EMAIL, SessionManager.DEMO_PASSWORD)
+
+        val client = HttpClient(MockEngine {
+            requests++
+            respond(ByteReadChannel(""), HttpStatusCode.OK)
+        })
+        val apiClient = DualisApiClient(client)
+        val authService = AuthenticationService(sessionManager, client)
+
+        return DualisGradeService(
+            gateway = DualisPageGateway(
+                apiClient,
+                sessionManager,
+                ReAuthenticator(sessionManager, authService)
+            ),
+            sessionManager = sessionManager,
+            gradeDao = MockGradeDao(),
+            gradeCacheMetadataDao = MockGradeCacheMetadataDao()
+        )
+    }
+
+    @Test
+    fun demoMode_listsThreeSemestersWithoutTalkingToDualis() = runTest {
+        val semesters = assertIs<Outcome.Ok<List<Semester>>>(createService(demo = true).getSemesters()).value
+
+        assertEquals(3, semesters.size)
+        assertTrue(semesters.all { it.name.isNotBlank() })
+        assertEquals(0, requests, "demo mode must not talk to Dualis")
+    }
+
+    @Test
+    fun demoMode_hasGradesForEverySemesterItLists() = runTest {
+        val service = createService(demo = true)
+        val semesters = assertIs<Outcome.Ok<List<Semester>>>(service.getSemesters()).value
+
+        for (semester in semesters) {
+            val grades = service.getGradesForSemester(semester).gradesOrFail()
+            assertTrue(grades.isNotEmpty(), "${semester.name} has no demo grades")
+        }
+        assertEquals(0, requests)
+    }
+
+    @Test
+    fun demoMode_carriesTheCasesTheScreenHasToSurvive() = runTest {
+        val service = createService(demo = true)
+        val semesters = assertIs<Outcome.Ok<List<Semester>>>(service.getSemesters()).value
+        val all = semesters.flatMap { service.getGradesForSemester(it).gradesOrFail() }
+
+        assertTrue(all.any { it.grade?.toDoubleOrNull() == null && it.grade != null }, "a numeric grade uses a comma")
+        assertTrue(all.any { it.grade == "b" }, "a module that is only passed or failed")
+        assertTrue(all.any { it.grade == null }, "a module that has no grade yet")
+        assertTrue(all.all { it.studentId == SessionManager.DEMO_EMAIL })
+    }
+
+    @Test
+    fun anUnknownSemester_hasNoDemoGrades() = runTest {
+        val grades = createService(demo = true)
+            .getGradesForSemester(Semester(id = "not-a-demo-semester", name = "WiSe 2020/21"))
+            .gradesOrFail()
+
+        assertTrue(grades.isEmpty())
+    }
+}

--- a/data/src/commonTest/kotlin/de/fampopprol/dhbwhorb/data/repository/AuthRepositoryLogoutTest.kt
+++ b/data/src/commonTest/kotlin/de/fampopprol/dhbwhorb/data/repository/AuthRepositoryLogoutTest.kt
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.data.repository
+
+import de.fampopprol.dhbwhorb.core.error.Outcome
+import de.fampopprol.dhbwhorb.data.dualis.remote.models.AuthData
+import de.fampopprol.dhbwhorb.data.dualis.remote.services.AuthenticationService
+import de.fampopprol.dhbwhorb.data.dualis.remote.session.ReAuthenticator
+import de.fampopprol.dhbwhorb.data.dualis.remote.session.SessionManager
+import de.fampopprol.dhbwhorb.data.storage.credentials.CredentialsStorageProvider
+import de.fampopprol.dhbwhorb.data.storage.credentials.FakeSecureStorage
+import de.fampopprol.dhbwhorb.net.ClearableCookiesStorage
+import de.fampopprol.dhbwhorb.testutil.MockAppDatabase
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.Cookie
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Logging out has to leave nothing of the account behind — not the credentials, not the session,
+ * and not the cookie the session is really carried in.
+ */
+class AuthRepositoryLogoutTest {
+
+    @Test
+    fun logout_clearsCredentials_session_andTheSessionCookie() = runTest {
+        val storage = FakeSecureStorage()
+        val sessionManager = SessionManager(storage)
+        val cookies = ClearableCookiesStorage()
+        val client = HttpClient(MockEngine { respond(ByteReadChannel(""), HttpStatusCode.OK) })
+        val authService = AuthenticationService(sessionManager, client, cookies)
+
+        val credentials = CredentialsStorageProvider(storage)
+        credentials.storeCredentials("test@dhbw.de", "password")
+        sessionManager.storeAuthData(AuthData(sessionId = "s", authToken = "t", cookie = "c"))
+        sessionManager.setDemoMode(true)
+        val dualis = Url("https://dualis.dhbw.de/")
+        cookies.addCookie(dualis, Cookie(name = "JSESSIONID", value = "abc", path = "/"))
+
+        val repository = AuthRepositoryImpl(
+            authenticationService = authService,
+            reAuthenticator = ReAuthenticator(sessionManager, authService),
+            credentialsProvider = credentials,
+            database = MockAppDatabase()
+        )
+
+        assertIs<Outcome.Ok<Unit>>(repository.logout())
+
+        assertFalse(credentials.hasStoredCredentials())
+        assertNull(sessionManager.getAuthData())
+        assertFalse(sessionManager.isDemoMode(), "demo mode is part of the session too")
+        assertTrue(cookies.get(dualis).isEmpty())
+    }
+}

--- a/data/src/commonTest/kotlin/de/fampopprol/dhbwhorb/net/ClearableCookiesStorageTest.kt
+++ b/data/src/commonTest/kotlin/de/fampopprol/dhbwhorb/net/ClearableCookiesStorageTest.kt
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.net
+
+import io.ktor.http.Cookie
+import io.ktor.http.Url
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ClearableCookiesStorageTest {
+
+    private val dualis = Url("https://dualis.dhbw.de/")
+
+    @Test
+    fun cookiesAreKept_untilTheyAreCleared() = runTest {
+        val storage = ClearableCookiesStorage()
+        storage.addCookie(dualis, Cookie(name = "JSESSIONID", value = "abc", path = "/"))
+
+        assertEquals("abc", storage.get(dualis).find { it.name == "JSESSIONID" }?.value)
+
+        storage.clear()
+
+        assertTrue(storage.get(dualis).isEmpty(), "the session cookie outlived the session")
+    }
+
+    @Test
+    fun theStorageStaysUsable_soTheNextLoginCanFillIt() = runTest {
+        val storage = ClearableCookiesStorage()
+        storage.addCookie(dualis, Cookie(name = "JSESSIONID", value = "first", path = "/"))
+        storage.clear()
+
+        storage.addCookie(dualis, Cookie(name = "JSESSIONID", value = "second", path = "/"))
+
+        assertEquals("second", storage.get(dualis).find { it.name == "JSESSIONID" }?.value)
+    }
+}

--- a/domain/src/commonMain/kotlin/de/fampopprol/dhbwhorb/domain/repository/DocumentRepository.kt
+++ b/domain/src/commonMain/kotlin/de/fampopprol/dhbwhorb/domain/repository/DocumentRepository.kt
@@ -19,8 +19,8 @@ interface DocumentRepository {
     /**
      * Download one document's bytes.
      *
-     * Fails with [de.fampopprol.dhbwhorb.core.error.AppError.Unsupported] in demo mode, where the
-     * listed documents are fixtures with no file behind them.
+     * In demo mode the bytes are a generated PDF rather than a request to Dualis, so the demo
+     * account reaches the viewer and the save dialog like any other.
      */
     suspend fun downloadDocument(document: DualisDocument): Outcome<ByteArray>
 }

--- a/domain/src/commonMain/kotlin/de/fampopprol/dhbwhorb/domain/session/SessionDataCleaner.kt
+++ b/domain/src/commonMain/kotlin/de/fampopprol/dhbwhorb/domain/session/SessionDataCleaner.kt
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.domain.session
+
+/**
+ * Something outside the repositories that still holds data belonging to the logged-in account.
+ *
+ * The database, the credentials and the session are [de.fampopprol.dhbwhorb.domain.repository.AuthRepository]'s
+ * to clear. What is left is everything the app handed to the *system*: scheduled reminders for
+ * lectures nobody is having any more, a home screen widget still drawing last week's timetable,
+ * document files written to a cache directory so a viewer could open them. None of it lives in a
+ * table, and all of it is the previous user's.
+ *
+ * An interface in `:domain` because [de.fampopprol.dhbwhorb.domain.usecase.Logout] has to call it
+ * while the implementations sit in `:services`, which depends on `:domain` and not the other way
+ * round.
+ */
+fun interface SessionDataCleaner {
+
+    /**
+     * Drop everything derived from the session that just ended.
+     *
+     * Runs after the session, the credentials and the cached tables are gone, so an implementation
+     * that reads the database sees it empty — which is what a widget refresh needs.
+     */
+    suspend fun clearSessionData()
+}

--- a/domain/src/commonMain/kotlin/de/fampopprol/dhbwhorb/domain/usecase/AuthUseCases.kt
+++ b/domain/src/commonMain/kotlin/de/fampopprol/dhbwhorb/domain/usecase/AuthUseCases.kt
@@ -11,6 +11,8 @@ import de.fampopprol.dhbwhorb.core.error.Outcome
 import de.fampopprol.dhbwhorb.domain.model.Session
 import de.fampopprol.dhbwhorb.domain.repository.AuthRepository
 import de.fampopprol.dhbwhorb.domain.repository.SessionRepository
+import de.fampopprol.dhbwhorb.domain.session.SessionDataCleaner
+import io.github.aakira.napier.Napier
 
 /** Log in with the credentials the user just typed. */
 class LoginWithCredentials(private val authRepository: AuthRepository) {
@@ -35,7 +37,37 @@ class RestoreSession(
     }
 }
 
-/** End the session and wipe everything derived from it. */
-class Logout(private val authRepository: AuthRepository) {
-    suspend operator fun invoke(): Outcome<Unit> = authRepository.logout()
+/**
+ * End the session and wipe everything derived from it.
+ *
+ * "Everything" is wider than the repository can reach: [AuthRepository.logout] clears the session,
+ * the credentials and the cached tables, and [cleaner] clears what the app handed to the system —
+ * scheduled reminders, the widget, cached document files. Both run on every logout; the next
+ * person to use this device must not find any of it.
+ *
+ * @param cleaner absent in the tests and on platforms that hand nothing to the system.
+ */
+class Logout(
+    private val authRepository: AuthRepository,
+    private val cleaner: SessionDataCleaner? = null
+) {
+    suspend operator fun invoke(): Outcome<Unit> {
+        val result = authRepository.logout()
+
+        // After the repository, so a cleaner that reads the database — the widget refresh does —
+        // sees it already empty.
+        val cleanerResult = cleaner?.let { clearWithCleaner(it) } ?: Outcome.Ok(Unit)
+
+        // The session is gone either way. Report the repository's failure first: a cache that is
+        // still on disk matters more than a widget that is still drawing.
+        return if (result is Outcome.Err) result else cleanerResult
+    }
+
+    private suspend fun clearWithCleaner(cleaner: SessionDataCleaner): Outcome<Unit> = try {
+        cleaner.clearSessionData()
+        Outcome.Ok(Unit)
+    } catch (e: Exception) {
+        Napier.e("Could not clear session data on logout: ${e.message}", e, tag = "Logout")
+        Outcome.Err(AppError.Storage("clearing session data on logout: ${e.message}"))
+    }
 }

--- a/domain/src/commonTest/kotlin/de/fampopprol/dhbwhorb/domain/usecase/LogoutTest.kt
+++ b/domain/src/commonTest/kotlin/de/fampopprol/dhbwhorb/domain/usecase/LogoutTest.kt
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.domain.usecase
+
+import de.fampopprol.dhbwhorb.core.error.AppError
+import de.fampopprol.dhbwhorb.core.error.Outcome
+import de.fampopprol.dhbwhorb.domain.model.Session
+import de.fampopprol.dhbwhorb.domain.repository.AuthRepository
+import de.fampopprol.dhbwhorb.domain.session.SessionDataCleaner
+import de.fampopprol.dhbwhorb.testutil.fakes.FakeAuthRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class LogoutTest {
+
+    @Test
+    fun logout_clearsTheRepositoryAndEverythingOutsideIt() = runTest {
+        val auth = FakeAuthRepository()
+        var cleared = 0
+
+        val result = Logout(auth, SessionDataCleaner { cleared++ })()
+
+        assertIs<Outcome.Ok<Unit>>(result)
+        assertEquals(1, auth.logoutCount)
+        assertEquals(1, cleared, "the reminders, widget and cached files must be cleared too")
+    }
+
+    @Test
+    fun theCleanerRunsAfterTheRepository_soItSeesAnEmptyDatabase() = runTest {
+        val order = mutableListOf<String>()
+        val auth = object : AuthRepository {
+            override suspend fun login(username: String, password: String) =
+                Outcome.Ok(Session(userFullName = null))
+
+            override suspend fun reAuthenticate() = login("", "")
+
+            override suspend fun logout(): Outcome<Unit> {
+                order += "repository"
+                return Outcome.Ok(Unit)
+            }
+        }
+
+        Logout(auth, SessionDataCleaner { order += "cleaner" })()
+
+        assertEquals(listOf("repository", "cleaner"), order)
+    }
+
+    @Test
+    fun aCleanerThatThrows_stillLogsOutAndReportsTheFailure() = runTest {
+        val auth = FakeAuthRepository()
+
+        val result = Logout(auth, SessionDataCleaner { throw IllegalStateException("no widget") })()
+
+        assertEquals(1, auth.logoutCount, "the session goes even if the cleanup does not")
+        val error = assertIs<Outcome.Err>(result).error
+        assertIs<AppError.Storage>(error)
+    }
+
+    @Test
+    fun aFailedRepository_isReportedEvenWhenTheCleanerSucceeds() = runTest {
+        val auth = FakeAuthRepository(logoutResult = Outcome.Err(AppError.Storage("db locked")))
+        var cleared = false
+
+        val result = Logout(auth, SessionDataCleaner { cleared = true })()
+
+        assertTrue(cleared, "a failed cache wipe must not skip the rest of the cleanup")
+        assertEquals(AppError.Storage("db locked"), assertIs<Outcome.Err>(result).error)
+    }
+
+    @Test
+    fun withoutACleaner_logoutIsStillTheRepository() = runTest {
+        val auth = FakeAuthRepository()
+
+        assertIs<Outcome.Ok<Unit>>(Logout(auth)())
+        assertEquals(1, auth.logoutCount)
+    }
+}

--- a/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/app/AppStore.kt
+++ b/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/app/AppStore.kt
@@ -11,6 +11,7 @@ import de.fampopprol.dhbwhorb.domain.repository.SessionRepository
 import de.fampopprol.dhbwhorb.domain.usecase.Logout
 import de.fampopprol.dhbwhorb.presentation.store.BaseStore
 import de.fampopprol.dhbwhorb.presentation.store.EffectScope
+import de.fampopprol.dhbwhorb.presentation.store.SessionScopedStore
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -23,7 +24,14 @@ import kotlinx.coroutines.CoroutineScope
 class AppStore(
     private val sessionRepository: SessionRepository,
     private val logout: Logout,
-    scope: CoroutineScope
+    scope: CoroutineScope,
+    /**
+     * The stores holding account data, resolved when a logout happens.
+     *
+     * A lambda rather than the list itself: these stores and this one are all singletons in the
+     * same graph, and asking for them while this one is being built is a cycle.
+     */
+    private val sessionScopedStores: () -> List<SessionScopedStore> = { emptyList() }
 ) : BaseStore<AppState, AppIntent, AppMsg, AppEffect>(
     initialState = AppState(),
     scope = scope
@@ -49,6 +57,12 @@ class AppStore(
 
             AppIntent.LogoutRequested -> {
                 val result = logout()
+
+                // The screens are singletons and would otherwise still be holding the previous
+                // user's grades and timetable when the next one logs in — visible until the first
+                // fetch replaces them.
+                sessionScopedStores().forEach { it.reset() }
+
                 // The session is gone either way, so the UI leaves regardless; a cache that could
                 // not be wiped is worth telling the user about, not worth blocking on.
                 emit(AppMsg.LoggedOut)

--- a/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/di/PresentationModule.kt
+++ b/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/di/PresentationModule.kt
@@ -28,7 +28,14 @@ import org.koin.dsl.module
 val presentationModule = module {
 
     single {
-        AppStore(sessionRepository = get(), logout = get(), scope = get())
+        AppStore(
+            sessionRepository = get(),
+            logout = get(),
+            scope = get(),
+            sessionScopedStores = {
+                listOf(get<TimetableStore>(), get<GradesStore>(), get<DocumentsStore>())
+            }
+        )
     }
 
     single {

--- a/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/documents/DocumentsStore.kt
+++ b/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/documents/DocumentsStore.kt
@@ -14,6 +14,7 @@ import de.fampopprol.dhbwhorb.domain.usecase.DownloadDocument
 import de.fampopprol.dhbwhorb.domain.usecase.ListDocuments
 import de.fampopprol.dhbwhorb.presentation.store.BaseStore
 import de.fampopprol.dhbwhorb.presentation.store.EffectScope
+import de.fampopprol.dhbwhorb.presentation.store.SessionScopedStore
 import kotlinx.coroutines.CoroutineScope
 
 class DocumentsStore(
@@ -24,7 +25,7 @@ class DocumentsStore(
 ) : BaseStore<DocumentsState, DocumentsIntent, DocumentsMsg, DocumentsEffect>(
     initialState = DocumentsState(),
     scope = scope
-) {
+), SessionScopedStore {
 
     /**
      * One list fetch at a time, and one download per document. Two different documents may

--- a/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/grades/GradesStore.kt
+++ b/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/grades/GradesStore.kt
@@ -15,6 +15,7 @@ import de.fampopprol.dhbwhorb.domain.usecase.ComputeGpa
 import de.fampopprol.dhbwhorb.domain.usecase.GetAllGrades
 import de.fampopprol.dhbwhorb.presentation.store.BaseStore
 import de.fampopprol.dhbwhorb.presentation.store.EffectScope
+import de.fampopprol.dhbwhorb.presentation.store.SessionScopedStore
 import kotlinx.coroutines.CoroutineScope
 
 class GradesStore(
@@ -25,7 +26,7 @@ class GradesStore(
 ) : BaseStore<GradesState, GradesIntent, GradesMsg, GradesEffect>(
     initialState = GradesState(),
     scope = scope
-) {
+), SessionScopedStore {
 
     /** Every intent loads grades, so only one of them may be in flight. */
     override fun dedupeKey(intent: GradesIntent): Any = "grades"

--- a/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/store/BaseStore.kt
+++ b/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/store/BaseStore.kt
@@ -58,6 +58,8 @@ abstract class BaseStore<S : Any, I : Any, M : Any, E : Any>(
     // close() cancels this store's work without touching the scope it was given.
     private val storeScope = scope + SupervisorJob(scope.coroutineContext[Job])
 
+    private val initial = initialState
+
     private val _state = MutableStateFlow(initialState)
     override val state = _state.asStateFlow()
 
@@ -131,6 +133,20 @@ abstract class BaseStore<S : Any, I : Any, M : Any, E : Any>(
             }
         }
         job.start()
+    }
+
+    /**
+     * Drop the state and everything still running, and start over.
+     *
+     * For logout: the store outlives the session, so what it holds has to be taken from it. The
+     * in-flight effects go first — a load that started before the logout would otherwise emit the
+     * previous user's data into the freshly emptied state.
+     */
+    open fun reset() {
+        val inFlight = running.value.values
+        running.value = emptyMap()
+        inFlight.forEach { it.cancel() }
+        _state.value = initial
     }
 
     override fun close() {

--- a/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/store/Store.kt
+++ b/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/store/Store.kt
@@ -39,3 +39,17 @@ interface Store<S : Any, I : Any, E : Any> {
     /** Cancel any work still running. After this the store is unusable. */
     fun close()
 }
+
+/**
+ * A store whose contents belong to one login.
+ *
+ * The stores are singletons that live as long as the app does — that is what makes switching tabs
+ * free. It also means the grades, the timetable and the document list survive a logout, and the
+ * next person to log in on this device saw them until the first fetch replaced them. Anything
+ * holding account data implements this so the root store can empty it.
+ */
+fun interface SessionScopedStore {
+
+    /** Throw away everything held and go back to the state a fresh store starts in. */
+    fun reset()
+}

--- a/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/timetable/TimetableStore.kt
+++ b/presentation/src/commonMain/kotlin/de/fampopprol/dhbwhorb/presentation/timetable/TimetableStore.kt
@@ -13,6 +13,7 @@ import de.fampopprol.dhbwhorb.domain.usecase.GetWeekTimetable
 import de.fampopprol.dhbwhorb.domain.usecase.RefreshTimetable
 import de.fampopprol.dhbwhorb.presentation.store.BaseStore
 import de.fampopprol.dhbwhorb.presentation.store.EffectScope
+import de.fampopprol.dhbwhorb.presentation.store.SessionScopedStore
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -30,7 +31,7 @@ class TimetableStore(
 ) : BaseStore<TimetableState, TimetableIntent, TimetableMsg, TimetableEffect>(
     initialState = TimetableState(),
     scope = scope
-) {
+), SessionScopedStore {
 
     /**
      * One load per week at a time. Refresh shares the key with load, so pulling to refresh while

--- a/presentation/src/commonTest/kotlin/de/fampopprol/dhbwhorb/presentation/app/AppStoreTest.kt
+++ b/presentation/src/commonTest/kotlin/de/fampopprol/dhbwhorb/presentation/app/AppStoreTest.kt
@@ -12,6 +12,7 @@ import de.fampopprol.dhbwhorb.domain.model.Session
 import de.fampopprol.dhbwhorb.domain.usecase.Logout
 import de.fampopprol.dhbwhorb.presentation.TestScopes
 import de.fampopprol.dhbwhorb.presentation.collectEffects
+import de.fampopprol.dhbwhorb.presentation.store.SessionScopedStore
 import de.fampopprol.dhbwhorb.testutil.fakes.FakeAuthRepository
 import de.fampopprol.dhbwhorb.testutil.fakes.FakeSessionRepository
 import kotlinx.coroutines.test.runTest
@@ -25,11 +26,13 @@ class AppStoreTest {
 
     private fun store(
         session: FakeSessionRepository,
-        auth: FakeAuthRepository = FakeAuthRepository()
+        auth: FakeAuthRepository = FakeAuthRepository(),
+        sessionScopedStores: () -> List<SessionScopedStore> = { emptyList() }
     ) = AppStore(
         sessionRepository = session,
         logout = Logout(auth),
-        scope = TestScopes.immediate()
+        scope = TestScopes.immediate(),
+        sessionScopedStores = sessionScopedStores
     )
 
     @Test
@@ -90,6 +93,23 @@ class AppStoreTest {
         assertFalse(state.isLoggedIn)
         assertNull(state.userFullName)
         assertFalse(state.isRestoring, "Logging out is not a restore")
+        store.close()
+    }
+
+    @Test
+    fun loggingOut_emptiesTheScreensThatHoldTheAccountsData() = runTest {
+        // The stores are singletons: without this the next person to log in on this device sees
+        // the previous one's grades until the first fetch comes back.
+        var resets = 0
+        val screens = List(3) { SessionScopedStore { resets++ } }
+        val store = store(
+            FakeSessionRepository(session = Session("Max Mustermann")),
+            sessionScopedStores = { screens }
+        )
+
+        store.dispatch(AppIntent.LogoutRequested)
+
+        assertEquals(3, resets)
         store.close()
     }
 

--- a/presentation/src/commonTest/kotlin/de/fampopprol/dhbwhorb/presentation/store/BaseStoreTest.kt
+++ b/presentation/src/commonTest/kotlin/de/fampopprol/dhbwhorb/presentation/store/BaseStoreTest.kt
@@ -166,6 +166,37 @@ class BaseStoreTest {
     }
 
     @Test
+    fun reset_dropsTheStateAndKeepsTheStoreUsable() = runTest {
+        val store = CounterStore()
+
+        store.dispatch(CounterIntent.Increment)
+        assertEquals(1, store.state.value.value)
+
+        store.reset()
+        assertEquals(CounterState(), store.state.value, "logout leaves nothing behind")
+
+        // Unlike close(), the store lives on — the next login uses the same instance.
+        store.dispatch(CounterIntent.Increment)
+        assertEquals(1, store.state.value.value)
+        store.close()
+    }
+
+    @Test
+    fun reset_cancelsWorkThatWouldLandAfterwards() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        val store = CounterStore(gate)
+
+        store.dispatch(CounterIntent.SlowIncrement)
+        store.reset()
+        gate.complete(Unit)
+
+        // A load started before the logout must not write the previous user's data into the
+        // emptied state.
+        assertEquals(CounterState(), store.state.value)
+        store.close()
+    }
+
+    @Test
     fun effectsAreNotReplayed() = runTest {
         val store = CounterStore()
 

--- a/services/src/androidMain/kotlin/de/fampopprol/dhbwhorb/services/di/ServicesPlatformModule.kt
+++ b/services/src/androidMain/kotlin/de/fampopprol/dhbwhorb/services/di/ServicesPlatformModule.kt
@@ -11,6 +11,8 @@ import de.fampopprol.dhbwhorb.services.notifications.LectureMonitorScheduler
 import de.fampopprol.dhbwhorb.services.notifications.NotificationDispatcher
 import de.fampopprol.dhbwhorb.services.reminders.AndroidLectureReminderScheduler
 import de.fampopprol.dhbwhorb.services.reminders.LectureReminderScheduler
+import de.fampopprol.dhbwhorb.services.session.AndroidCachedFileCleaner
+import de.fampopprol.dhbwhorb.services.session.CachedFileCleaner
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -19,4 +21,7 @@ actual fun servicesPlatformModule(): Module = module {
     single<NotificationDispatcher> { AndroidNotificationDispatcher(androidContext()) }
     single { LectureMonitorScheduler(androidContext()) }
     single<LectureReminderScheduler> { AndroidLectureReminderScheduler(androidContext(), settings = get()) }
+
+    // Only Android writes documents to a cache directory; see AndroidCachedFileCleaner.
+    single<CachedFileCleaner> { AndroidCachedFileCleaner(androidContext()) }
 }

--- a/services/src/androidMain/kotlin/de/fampopprol/dhbwhorb/services/notifications/AndroidNotificationDispatcher.kt
+++ b/services/src/androidMain/kotlin/de/fampopprol/dhbwhorb/services/notifications/AndroidNotificationDispatcher.kt
@@ -135,6 +135,11 @@ class AndroidNotificationDispatcher(private val context: Context) : Notification
      * Show a summary notification for multiple lecture changes.
      */
     @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+    override suspend fun cancelAllDelivered() {
+        Napier.d("Cancelling all delivered notifications", tag = TAG)
+        NotificationManagerCompat.from(context).cancelAll()
+    }
+
     override suspend fun showSummaryNotification(title: String, message: String, changeCount: Int) {
         if (!hasPermission()) {
             Napier.w("Cannot show notification: permission not granted", tag = TAG)

--- a/services/src/androidMain/kotlin/de/fampopprol/dhbwhorb/services/session/AndroidCachedFileCleaner.kt
+++ b/services/src/androidMain/kotlin/de/fampopprol/dhbwhorb/services/session/AndroidCachedFileCleaner.kt
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.services.session
+
+import android.content.Context
+import io.github.aakira.napier.Napier
+
+private const val TAG = "CachedFileCleaner"
+
+/**
+ * Deletes the document copies `openFile` writes into the cache directory.
+ *
+ * Opening a document from Dualis means writing it to `cacheDir` and handing a `content://` URI to
+ * whichever app can display it — so a transcript of records stays readable on the device long
+ * after the account it belongs to has been logged out of.
+ *
+ * Only the files directly in `cacheDir`, which are the ones this app puts there. The
+ * subdirectories belong to libraries with their own bookkeeping, and deleting under them is their
+ * problem to be surprised by, not ours to cause.
+ */
+class AndroidCachedFileCleaner(private val context: Context) : CachedFileCleaner {
+
+    override fun deleteAll() {
+        val files = context.cacheDir?.listFiles()?.filter { it.isFile }.orEmpty()
+        val deleted = files.count { it.delete() }
+        Napier.d("Deleted $deleted of ${files.size} cached file(s)", tag = TAG)
+    }
+}

--- a/services/src/commonMain/kotlin/de/fampopprol/dhbwhorb/services/di/ServicesModule.kt
+++ b/services/src/commonMain/kotlin/de/fampopprol/dhbwhorb/services/di/ServicesModule.kt
@@ -6,9 +6,12 @@
 
 package de.fampopprol.dhbwhorb.services.di
 
+import de.fampopprol.dhbwhorb.domain.session.SessionDataCleaner
 import de.fampopprol.dhbwhorb.services.notifications.LectureChangeMonitor
 import de.fampopprol.dhbwhorb.services.notifications.NotificationManager
 import de.fampopprol.dhbwhorb.services.reminders.LectureReminderPlanner
+import de.fampopprol.dhbwhorb.services.session.AppSessionDataCleaner
+import de.fampopprol.dhbwhorb.services.session.CachedFileCleaner
 import de.fampopprol.dhbwhorb.services.widget.WidgetRefresher
 import de.fampopprol.dhbwhorb.services.widget.WidgetTimetableUseCase
 import org.koin.core.module.Module
@@ -39,6 +42,17 @@ val servicesModule = module {
             // Android binds a Glance refresher in :composeApp, iOS one that calls into Swift.
             // Desktop binds none, and nothing about that is a failure.
             widgetRefresher = getOrNull<WidgetRefresher>()
+        )
+    }
+
+    // What logout has to undo outside the database. Resolved by the Logout use case, which lives
+    // in :domain and cannot see any of these types.
+    single<SessionDataCleaner> {
+        AppSessionDataCleaner(
+            reminders = get(),
+            notifications = get(),
+            widgetRefresher = getOrNull<WidgetRefresher>(),
+            cachedFiles = getOrNull<CachedFileCleaner>(),
         )
     }
 

--- a/services/src/commonMain/kotlin/de/fampopprol/dhbwhorb/services/notifications/NotificationDispatcher.kt
+++ b/services/src/commonMain/kotlin/de/fampopprol/dhbwhorb/services/notifications/NotificationDispatcher.kt
@@ -41,6 +41,17 @@ interface NotificationDispatcher {
     suspend fun showNotification(title: String, message: String, notificationKey: String)
 
     /**
+     * Remove the notifications this app has already delivered.
+     *
+     * Called on logout: a notification saying a lecture moved is as much the previous user's data
+     * as the row it was derived from, and it survives the app being closed.
+     *
+     * Default-empty rather than abstract, because on the desktop a notification is handed to the
+     * system and forgotten — there is nothing left to take back.
+     */
+    suspend fun cancelAllDelivered() {}
+
+    /**
      * Show a notification for multiple lecture changes (summary).
      * @param title Notification title
      * @param message Notification message body

--- a/services/src/commonMain/kotlin/de/fampopprol/dhbwhorb/services/session/AppSessionDataCleaner.kt
+++ b/services/src/commonMain/kotlin/de/fampopprol/dhbwhorb/services/session/AppSessionDataCleaner.kt
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.services.session
+
+import de.fampopprol.dhbwhorb.domain.session.SessionDataCleaner
+import de.fampopprol.dhbwhorb.services.notifications.NotificationDispatcher
+import de.fampopprol.dhbwhorb.services.reminders.LectureReminderScheduler
+import de.fampopprol.dhbwhorb.services.widget.WidgetRefresher
+import io.github.aakira.napier.Napier
+
+private const val TAG = "SessionDataCleaner"
+
+/**
+ * Everything the app left outside its own storage, undone.
+ *
+ * Clearing the database is not enough on a phone: the alarms for next week's lectures are held by
+ * the system, the widget keeps drawing whatever it last read, notifications about changed lectures
+ * stay in the shade, and a document that was opened is a file in the cache directory. All four
+ * outlive both the session and the tables it came from.
+ *
+ * Each step is independent and none may stop the others — a widget that cannot be refreshed must
+ * not leave next week's alarms in place.
+ */
+class AppSessionDataCleaner(
+    private val reminders: LectureReminderScheduler,
+    private val notifications: NotificationDispatcher,
+    private val widgetRefresher: WidgetRefresher?,
+    private val cachedFiles: CachedFileCleaner?,
+) : SessionDataCleaner {
+
+    override suspend fun clearSessionData() {
+        step("cancelling scheduled reminders") { reminders.replaceAll(emptyList()) }
+        step("removing delivered notifications") { notifications.cancelAllDelivered() }
+        step("deleting cached files") { cachedFiles?.deleteAll() }
+        // Last: the widget reads the database, which by now is empty, so this is what makes it
+        // draw an empty week instead of the previous user's.
+        step("refreshing the widget") { widgetRefresher?.requestRefresh() }
+    }
+
+    private suspend fun step(what: String, block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: Exception) {
+            Napier.e("Logout: $what failed: ${e.message}", e, tag = TAG)
+        }
+    }
+}
+
+/**
+ * Files the app wrote outside the database — on Android, the copies in the cache directory that
+ * let a viewer open a downloaded document.
+ *
+ * Bound only where such files exist; [AppSessionDataCleaner] takes it as null everywhere else.
+ */
+fun interface CachedFileCleaner {
+    fun deleteAll()
+}

--- a/services/src/commonMain/kotlin/de/fampopprol/dhbwhorb/services/widget/WidgetRefresher.kt
+++ b/services/src/commonMain/kotlin/de/fampopprol/dhbwhorb/services/widget/WidgetRefresher.kt
@@ -15,6 +15,6 @@ package de.fampopprol.dhbwhorb.services.widget
  *
  * Background work resolves it optionally — a missing widget refresh must never fail the caller.
  */
-interface WidgetRefresher {
+fun interface WidgetRefresher {
     fun requestRefresh()
 }

--- a/services/src/commonTest/kotlin/de/fampopprol/dhbwhorb/services/session/AppSessionDataCleanerTest.kt
+++ b/services/src/commonTest/kotlin/de/fampopprol/dhbwhorb/services/session/AppSessionDataCleanerTest.kt
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Joinside <suitor-fall-life@duck.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package de.fampopprol.dhbwhorb.services.session
+
+import de.fampopprol.dhbwhorb.services.notifications.NotificationDispatcher
+import de.fampopprol.dhbwhorb.services.reminders.LectureReminder
+import de.fampopprol.dhbwhorb.services.reminders.LectureReminderScheduler
+import de.fampopprol.dhbwhorb.services.widget.WidgetRefresher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private class RecordingScheduler(
+    private val onReplace: () -> Unit = {}
+) : LectureReminderScheduler {
+    var lastScheduled: List<LectureReminder>? = null
+
+    override suspend fun replaceAll(reminders: List<LectureReminder>) {
+        onReplace()
+        lastScheduled = reminders
+    }
+
+    override fun firesExactly(): Boolean = true
+}
+
+private class RecordingDispatcher : NotificationDispatcher {
+    var cancelled = 0
+
+    override suspend fun requestPermission(): Boolean = true
+    override suspend fun hasPermission(): Boolean = true
+    override suspend fun showNotification(title: String, message: String, notificationKey: String) = Unit
+    override suspend fun showSummaryNotification(title: String, message: String, changeCount: Int) = Unit
+    override suspend fun cancelAllDelivered() {
+        cancelled++
+    }
+}
+
+class AppSessionDataCleanerTest {
+
+    @Test
+    fun clearing_cancelsRemindersNotificationsFilesAndRefreshesTheWidget() = runTest {
+        val scheduler = RecordingScheduler()
+        val dispatcher = RecordingDispatcher()
+        var refreshes = 0
+        var filesDeleted = 0
+
+        AppSessionDataCleaner(
+            reminders = scheduler,
+            notifications = dispatcher,
+            widgetRefresher = WidgetRefresher { refreshes++ },
+            cachedFiles = CachedFileCleaner { filesDeleted++ },
+        ).clearSessionData()
+
+        assertEquals(emptyList(), scheduler.lastScheduled, "every alarm has to go")
+        assertEquals(1, dispatcher.cancelled)
+        assertEquals(1, filesDeleted)
+        assertEquals(1, refreshes, "the widget still draws the old week until it is told")
+    }
+
+    @Test
+    fun aFailingStep_doesNotStopTheOthers() = runTest {
+        val dispatcher = RecordingDispatcher()
+        var refreshes = 0
+
+        AppSessionDataCleaner(
+            reminders = RecordingScheduler { throw IllegalStateException("no alarm manager") },
+            notifications = dispatcher,
+            widgetRefresher = WidgetRefresher { refreshes++ },
+            cachedFiles = null,
+        ).clearSessionData()
+
+        assertEquals(1, dispatcher.cancelled)
+        assertEquals(1, refreshes)
+    }
+
+    @Test
+    fun withoutAWidgetOrCachedFiles_theRestStillRuns() = runTest {
+        val scheduler = RecordingScheduler()
+        val dispatcher = RecordingDispatcher()
+
+        AppSessionDataCleaner(
+            reminders = scheduler,
+            notifications = dispatcher,
+            widgetRefresher = null,
+            cachedFiles = null,
+        ).clearSessionData()
+
+        assertTrue(scheduler.lastScheduled?.isEmpty() == true)
+        assertEquals(1, dispatcher.cancelled)
+    }
+}

--- a/services/src/iosMain/kotlin/de/fampopprol/dhbwhorb/services/notifications/IosNotificationDispatcher.kt
+++ b/services/src/iosMain/kotlin/de/fampopprol/dhbwhorb/services/notifications/IosNotificationDispatcher.kt
@@ -95,6 +95,11 @@ class IosNotificationDispatcher : NotificationDispatcher {
     /**
      * Show a summary notification for multiple lecture changes.
      */
+    override suspend fun cancelAllDelivered() {
+        Napier.d("Cancelling all delivered notifications (iOS)", tag = TAG)
+        notificationCenter.removeAllDeliveredNotifications()
+    }
+
     override suspend fun showSummaryNotification(title: String, message: String, changeCount: Int) {
         if (!hasPermission()) {
             Napier.w("Cannot show notification: permission not granted", tag = TAG)

--- a/services/src/macosMain/kotlin/de/fampopprol/dhbwhorb/services/notifications/MacosNotificationDispatcher.kt
+++ b/services/src/macosMain/kotlin/de/fampopprol/dhbwhorb/services/notifications/MacosNotificationDispatcher.kt
@@ -97,6 +97,11 @@ class MacosNotificationDispatcher : NotificationDispatcher {
     /**
      * Show a summary notification for multiple lecture changes.
      */
+    override suspend fun cancelAllDelivered() {
+        Napier.d("Cancelling all delivered notifications (macOS)", tag = TAG)
+        notificationCenter.removeAllDeliveredNotifications()
+    }
+
     override suspend fun showSummaryNotification(title: String, message: String, changeCount: Int) {
         if (!hasPermission()) {
             Napier.w("Cannot show notification: permission not granted", tag = TAG)


### PR DESCRIPTION
## What changed

Two things the app got wrong for anyone who logs out, and two gaps in the demo account.

### Logout now clears every trace of the account

Before this, logging out cleared the session, the credentials and the Room tables — and left everything else behind:

| What survived a logout | Now |
|---|---|
| The session cookie in the shared Ktor client, so the next login started by presenting the previous account's `JSESSIONID` | `ClearableCookiesStorage`, emptied in `AuthenticationService.logout()` |
| Scheduled lecture reminders (system alarms / pending notifications) for lectures of the previous user | `LectureReminderScheduler.replaceAll(emptyList())` |
| Change notifications already sitting in the notification shade | new `NotificationDispatcher.cancelAllDelivered()` (Android, iOS, macOS; default no-op on desktop) |
| The home screen widget, still drawing last week's timetable | widget refresh, run *after* the database is emptied |
| On Android: downloaded documents written to `cacheDir` so a viewer could open them | `AndroidCachedFileCleaner` |
| The presentation stores — singletons, so grades, timetable and documents stayed in memory and were visible to the next person to log in until the first fetch replaced them | `BaseStore.reset()`, dispatched by `AppStore` on logout |

The parts outside the repository's reach are wired through a new `SessionDataCleaner` interface in `:domain`, because `Logout` has to call them while the implementations live in `:services`. Every step is independent and failure-tolerant: a widget that cannot be refreshed must not leave next week's alarms in place, and the user ends up logged out either way.

Deliberately **not** cleared: theme, language and notification preferences. Those are device settings, not account data.

### The demo account has grades and downloadable documents

Opening the grades screen in demo mode used to walk into the page gateway, find no session id, fail to re-authenticate an account that never logs in, and end as *"Your session has expired. Please log in again."* — advice that leads nowhere for a user who has no session to expire.

`DualisGradeService` now serves demo data, and `DemoDataProvider` gained three semesters of a dual computer science course. The current semester holds exactly the modules the demo timetable teaches, so the two screens describe the same student. The grade mix is deliberate — numeric grades, a `b` for a pass/fail module, and modules with no grade yet — because those are the three cases the grades screen, the credit count and the average have to survive.

Semester names are derived from the current date (`WiSe 2025/26`, `SoSe 2026`), like the demo timetable is generated around the current week: a hard-coded `WiSe 2024/25` looks like a broken account two years later.

The three demo documents were listed but refused to download. They now hand over a real PDF, so the demo goes all the way through open and save, including the platform file dialogs. `DemoPdf` writes the file by hand — the alternative is a PDF library on four platforms for one page of text — using the standard Helvetica and Courier faces, WinAnsi encoding so umlauts survive, and real byte offsets in the cross-reference table. About 1.2 KB per file. Every page is footed with *"Beispieldokument des Demo-Kontos - keine gültige Bescheinigung."*

## For the reviewer

- `AuthenticationService.logout()` is now `suspend` (it clears the cookie storage). The only callers are the repository and the test mock.
- `WidgetRefresher` and `SessionScopedStore` are `fun interface`s so the tests can pass lambdas.
- The generated PDFs were rendered through Quick Look to confirm real readers open them; `DemoPdfTest` checks the structure that a reader would actually reject a file over — every xref entry pointing at its object, `startxref` pointing at the table, and `/Length` matching the real stream length.
- Demo grades do not go through the Room cache; they are served straight from the provider. Nothing is written, so nothing has to be cleared on logout.

## Testing

455 desktop tests pass. New: `LogoutTest`, `AppSessionDataCleanerTest`, `AuthRepositoryLogoutTest`, `ClearableCookiesStorageTest`, `DemoDataProviderTest`, `DemoPdfTest`, `DualisGradeServiceDemoTest`, plus reset coverage in `BaseStoreTest` and `AppStoreTest`. Android, iOS and macOS targets compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
